### PR TITLE
Add CHANGELOG.md for tracking version history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# CHANGELOG
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Add CHANGELOG for version tracking, [!37](https://github.com/VortexCoyote/leraine-studio/pull/37)
+
+[Unreleased]: https://github.com/VortexCoyote/leraine-studio/compare/v1.0.1...master
+
+## [1.0.1] - 2021-08-14
+
+### Fixes
+
+- Fix for crash when editing text fields, [9118923](https://github.com/VortexCoyote/leraine-studio/commit/91189231b48bf118e7655e8a8e5b94a2e9f28002)
+
+[1.0.1]: https://github.com/VortexCoyote/leraine-studio/compare/v1.0.0...v1.0.1
+
+## [1.0.0] - 2021-08-14
+
+- Initial release
+
+[1.0.0]: https://github.com/VortexCoyote/leraine-studio/releases/tag/v1.0.0


### PR DESCRIPTION
I propose to create a `CHANGELOG.md` document to project where to list changes between versions so it's easy to find all such info in one document.

I've seen arguments about moving to GitHub releases instead, but IMHO it's messy and hard to find actual differences.

This is heavily inspired by [keepachangelog v1.0.0](https://keepachangelog.com/en/1.0.0/).

In order for this to work, CHANGELOG should be maintained after every PR merge, so it's up-to-date, but it's up-to this project maintainers to see if they want to or not.